### PR TITLE
Fix no HDMI signal after wake from sleep

### DIFF
--- a/CLOVER/config.plist
+++ b/CLOVER/config.plist
@@ -309,7 +309,7 @@
 	<key>Boot</key>
 	<dict>
 		<key>Arguments</key>
-		<string>dart=0 darkwake=1 agdpmod=vit9696 brcmfx-country=#a keepsyms=1 -lilubetaall bpr_probedelay=100 bpr_initialdelay=300 bpr_postresetdelay=300</string>
+		<string>dart=0 darkwake=1 agdpmod=vit9696 brcmfx-country=#a keepsyms=1 -lilubetaall bpr_probedelay=100 bpr_initialdelay=300 bpr_postresetdelay=300 igfxonln=1</string>
 		<key>CustomLogo</key>
 		<string>Alternate</string>
 		<key>Debug</key>


### PR DESCRIPTION
See Issue #142. This issue can be fixed by adding igfxonln=1 boot argument for WhateverGreen.